### PR TITLE
escape filename shell arguments

### DIFF
--- a/code/FFmpeg.php
+++ b/code/FFmpeg.php
@@ -72,10 +72,10 @@ class FFmpeg extends Object implements Video_Backend
         $return = null;
         $cmd = $this->config()->get('ffmpeg_path');
         foreach ($infile_options as $key => $val) $cmd .= ' -' . $key . ' ' . $val;
-        $cmd .= ' -i ' . $infile;
+        $cmd .= ' -i ' . escapeshellarg($infile);
         foreach ($outfile_options as $key => $val) $cmd .= ' -' . $key . ' ' . $val;
         if ($outfile) {
-            $cmd .= ' ' . $outfile;
+            $cmd .= ' ' . escapeshellarg($outfile);
             if (!file_exists(dirname($outfile))) mkdir(dirname($outfile));
         }
         $cmd .= ' 2>&1';


### PR DESCRIPTION
Thanks for your work on this module.

I've got some special characters in the directory path I use for web projects, and it was necessary for me to escape the filename arguments. 

I'm not sure whether escaping like this could cause problems in some environments - my guess is that it's safe.

Please let me know if you have any questions. Thanks again.